### PR TITLE
Removed incorrect or unnecessary comments, unused SWIhandler method,

### DIFF
--- a/qcore.c
+++ b/qcore.c
@@ -195,7 +195,6 @@ void interrupt_handler (void)
 
     if (ipending)
     {
-      // This currently has no actions, but this will never be called. It will always go to the else since there are no hardware interrupts yet
       if (ipending & 0x1)
       {
         // clear the interrupt

--- a/qcore.h
+++ b/qcore.h
@@ -47,7 +47,6 @@ typedef struct  _process
 
 extern void QuenosNewProcess (void (*entry_point) (void), char *stack_bottom, int stack_size);
 extern void ShowReadyQueue (void);
-extern void QuenosSWIHandler (void);
 extern void QuenosDispatch (void);
 
 extern unsigned int process_stack_pointer;

--- a/quser.c
+++ b/quser.c
@@ -14,7 +14,6 @@ DESCRIPTION:	Definitions of functions for user processes, including a
 ******************************************************************************/
 
 #include "quser.h"
-#include "qcore.h"
 
 #define USER_STACK_SIZE 256
 

--- a/request.s
+++ b/request.s
@@ -1,16 +1,12 @@
 .section .text
 
 .global KernelRelinquish
-#.type KernelRelinquish, @function
 .global KernelBlock
-#.type KernelBlock, @function
 .global KernelUnblock
-#.type KernelUnblock, @function
 .global KernelSendMessage
 .global KernelReadMessage
 .global KernelTimerDelay
 .global KernelPBBlock
-
 
 #qrequest.s contains functions to set up relevant information when requesting kernel service.
 # We enter the kernel using trap, and expect the ?xception handler to automatically save everything onto the stack for us
@@ -19,7 +15,7 @@
 KernelRelinquish:
     subi sp, sp, 4
     stw r5, 0(sp)
-    movi r5,0 #relinquish enum, TODO: Ask if this enum should start at 1 for possibility of 0 being a common garbage value that could be misread
+    movi r5,0 #relinquish enum
     trap
     ldw r5, 0(sp)
     addi sp,sp,4
@@ -66,8 +62,8 @@ KernelReadMessage:
     stw r5, 0(sp)
     movi r5, 4 # read message enum
     trap
-    # We will expect (and accept) that the interrupt handler method called by exception_handler.c will overwrite the values to load
-    # into r2
+    # We will expect (and accept) that the interrupt handler method called by exception_handler.c will overwrite the
+    # values to load into r2
     ldw r5, 0(sp)
     addi sp,sp,4
     ret


### PR DESCRIPTION
unreferenced header file. Questions to be raised about current expected
behavior and possibly redundant State enums in qcore.h when we already have request
enums in qcore.h